### PR TITLE
Updated Gemfile for compatibility with jekyll docker images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 source "https://rubygems.org"
-gem "jekyll"
+gem 'jekyll', '= 3.9.5'
+gem "github-pages"
+gem 'rexml'
+gem "webrick", "~> 1.8"


### PR DESCRIPTION
I'm submitting this one humbly as someone brand new to Ruby. 

I was getting tons of errors trying to build the site locally -- despite that it worked fine on Github pages. So I tried a number of Docker containers and was still getting miscellaneous errors. 

With this patch, it will build using the [JV-conseil/jekyll-docker image](https://github.com/JV-conseil/jekyll-docker). It also continues to build on Github pages. 


